### PR TITLE
Replace /todo route with product catalogue + expandable detail prototype

### DIFF
--- a/src/routes/TodoPage.tsx
+++ b/src/routes/TodoPage.tsx
@@ -1,771 +1,105 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { KeyboardEvent, MouseEvent } from 'react';
+import { useMemo, useState } from 'react';
 import styled from 'styled-components';
-import type { Task, TaskFilter, TaskSort } from '../types/todo';
-import TodoToolbar from '../components/todo/TodoToolbar';
-import TodoList, { type DropPosition, type TaskGroup } from '../components/todo/TodoList';
-import TodoBulkBar from '../components/todo/TodoBulkBar';
 
-const PageShell = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-  padding: calc(var(--space-2) * 1.5);
-  gap: calc(var(--space-2) * 1.5);
-  background: var(--color-surface);
-`;
+type PanelTab = 'Overview' | 'Variants' | 'Inventory' | 'Suppliers' | 'Media' | 'History';
+type DetailTab = 'Variants' | 'Attributes' | 'Inventory' | 'Suppliers' | 'Media' | 'History' | 'Change log';
 
-const ContentArea = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-`;
-
-const LiveRegion = styled.div`
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-`;
-
-type GroupKey = 'overdue' | 'today' | 'upcoming' | 'completed';
-
-interface DropPreviewState {
+interface Product {
   id: string;
-  position: DropPosition | null;
+  name: string;
+  code: string;
+  brand: string;
+  area: string;
+  category: string;
+  rrp: string;
+  status: 'LIVE' | 'PENDING' | 'DRAFT';
+  stock: number;
+  updated: string;
 }
 
-interface KeyboardDragState {
-  id: string | null;
-  originIndex: number;
-}
+const products: Product[] = [
+  { id: '45075832', name: 'ASOS DESIGN cropped blazer in black', code: '45075832', brand: 'ASOS DESIGN', area: 'Womenswear', category: 'Tailoring', rrp: '£45.00', status: 'LIVE', stock: 120, updated: '21 May 2024' },
+  { id: '27123456', name: 'Nike Air Force 1 ’07 trainers in white', code: '27123456', brand: 'Nike', area: 'Menswear', category: 'Footwear', rrp: '£110.00', status: 'LIVE', stock: 58, updated: '21 May 2024' },
+  { id: '62789123', name: 'New Look tiered smock dress in cream floral', code: '62789123', brand: 'New Look', area: 'Womenswear', category: 'Dresses', rrp: '£28.99', status: 'PENDING', stock: 0, updated: '20 May 2024' },
+  { id: '57689102', name: 'Topshop straight leg jean in mid blue', code: '57689102', brand: 'Topshop', area: 'Womenswear', category: 'Denim', rrp: '£40.00', status: 'LIVE', stock: 210, updated: '20 May 2024' },
+];
 
-const initialTasks: Task[] = normaliseOrders([
-  {
-    id: 'task-1',
-    title: 'Prep the lookbook moodboard',
-    description: 'Curate 12 hero images and annotate palette options.',
-    due: shiftDayISO(-1),
-    priority: 'high',
-    tags: ['Styling', 'Campaign'],
-    projectId: 'proj-brand',
-    completed: false,
-    updatedAt: shiftTimestamp(-2, 10),
-    order: 1,
-  },
-  {
-    id: 'task-2',
-    title: 'Confirm influencer shortlist',
-    description: 'Send the final shortlist to PR for approval.',
-    due: shiftDayISO(0),
-    priority: 'medium',
-    tags: ['PR'],
-    projectId: 'proj-brand',
-    completed: false,
-    updatedAt: shiftTimestamp(-1, 20),
-    order: 2,
-  },
-  {
-    id: 'task-3',
-    title: 'Plan push notifications cadence',
-    description: 'Draft copy variants and schedule times.',
-    due: shiftDayISO(2),
-    priority: 'low',
-    tags: ['CRM', 'Mobile'],
-    projectId: 'proj-growth',
-    completed: false,
-    updatedAt: shiftTimestamp(-3, 12),
-    order: 3,
-  },
-  {
-    id: 'task-4',
-    title: 'Retouch studio shoot selects',
-    description: 'Apply consistent lighting and export web-ready assets.',
-    due: shiftDayISO(3),
-    priority: 'high',
-    tags: ['Creative'],
-    projectId: 'proj-creative',
-    completed: true,
-    updatedAt: shiftTimestamp(-1, 3),
-    order: 4,
-  },
-  {
-    id: 'task-5',
-    title: 'Finalize paid social budget',
-    description: 'Update the spreadsheet with latest CPM projections.',
-    due: shiftDayISO(-3),
-    priority: 'medium',
-    tags: ['Performance'],
-    projectId: 'proj-growth',
-    completed: false,
-    updatedAt: shiftTimestamp(-4, 16),
-    order: 5,
-  },
-  {
-    id: 'task-6',
-    title: 'Wrap UX copy QA',
-    description: 'Proof microcopy for the checkout flow A/B test.',
-    due: undefined,
-    priority: 'low',
-    tags: ['UX'],
-    projectId: 'proj-product',
-    completed: true,
-    updatedAt: shiftTimestamp(0, -3),
-    order: 6,
-  },
-]);
+const variants = [4, 6, 8, 10, 12].map((size, i) => ({ size, sku: `45075832-${size}`, ean: `50596712345${67 + i}`, stock: [12, 18, 20, 22, 20][i], available: [10, 15, 16, 18, 17][i] }));
 
 export default function TodoPage() {
-  const [tasks, setTasks] = useState<Task[]>(initialTasks);
-  const [filter, setFilter] = useState<TaskFilter>('all');
-  const [sort, setSort] = useState<TaskSort>('due');
-  const [tagFilter, setTagFilter] = useState<string | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [focusedId, setFocusedId] = useState<string | undefined>(initialTasks[0]?.id);
-  const [anchorId, setAnchorId] = useState<string | undefined>(initialTasks[0]?.id);
-  const [draggingId, setDraggingId] = useState<string | undefined>(undefined);
-  const [dropPreview, setDropPreview] = useState<DropPreviewState | null>(null);
-  const [shakeIds, setShakeIds] = useState<Set<string>>(new Set());
-  const [keyboardDrag, setKeyboardDrag] = useState<KeyboardDragState>({ id: null, originIndex: -1 });
-  const [scheduleTaskId, setScheduleTaskId] = useState<string | undefined>(undefined);
-  const [quickAddValue, setQuickAddValue] = useState('');
-  const [liveMessage, setLiveMessage] = useState('');
-  const quickAddFocusRef = useRef<HTMLInputElement | null>(null);
-  const shakeTimeouts = useRef<Map<string, number>>(new Map());
-
-  const triggerShake = useCallback((taskId: string) => {
-    setShakeIds((prev) => {
-      const next = new Set(prev);
-      next.add(taskId);
-      return next;
-    });
-    const existing = shakeTimeouts.current.get(taskId);
-    if (existing) {
-      window.clearTimeout(existing);
-    }
-    const timeoutId = window.setTimeout(() => {
-      setShakeIds((prev) => {
-        const next = new Set(prev);
-        next.delete(taskId);
-        return next;
-      });
-      shakeTimeouts.current.delete(taskId);
-    }, 180);
-    shakeTimeouts.current.set(taskId, timeoutId);
-  }, []);
-
-  const groups = useMemo<TaskGroup[]>(() => {
-    const now = new Date();
-    const result = buildGroups(tasks, filter, sort, tagFilter, now);
-    return result;
-  }, [tasks, filter, sort, tagFilter]);
-
-  const flatTaskIds = useMemo(() => groups.flatMap((group) => group.tasks.map((task) => task.id)), [groups]);
-
-  useEffect(() => {
-    if (focusedId && !flatTaskIds.includes(focusedId)) {
-      setFocusedId(flatTaskIds[0]);
-    }
-    setSelectedIds((prev) => {
-      let changed = false;
-      const next = new Set<string>();
-      prev.forEach((id) => {
-        if (flatTaskIds.includes(id)) {
-          next.add(id);
-        } else {
-          changed = true;
-        }
-      });
-      return changed ? next : prev;
-    });
-    setAnchorId((prev) => {
-      if (!prev || flatTaskIds.includes(prev)) return prev;
-      return flatTaskIds[0];
-    });
-  }, [flatTaskIds, focusedId]);
-
-  useEffect(
-    () => () => {
-      shakeTimeouts.current.forEach((timeoutId) => window.clearTimeout(timeoutId));
-      shakeTimeouts.current.clear();
-    },
-    [],
-  );
-
-  const availableTags = useMemo(() => {
-    const tagSet = new Set<string>();
-    for (const task of tasks) {
-      task.tags.forEach((tag) => tagSet.add(tag));
-    }
-    return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
-  }, [tasks]);
-
-  const handleSelectTask = (taskId: string, event: MouseEvent | KeyboardEvent) => {
-    const isMeta = 'metaKey' in event ? event.metaKey || event.ctrlKey : false;
-    const isShift = 'shiftKey' in event ? event.shiftKey : false;
-
-    if (event.type === 'keydown') {
-      const keyEvent = event as KeyboardEvent;
-      if (keyEvent.key === ' ' || keyEvent.key === 'Enter') {
-        keyEvent.preventDefault();
-      } else {
-        return;
-      }
-    }
-
-    setFocusedId(taskId);
-
-    if (isShift) {
-      rangeSelect(taskId);
-    } else if (isMeta) {
-      toggleSelect(taskId);
-    } else {
-      replaceSelection(taskId);
-    }
-  };
-
-  const handleFocusTask = (taskId: string) => {
-    setFocusedId(taskId);
-    if (!selectedIds.size) {
-      setAnchorId(taskId);
-    }
-  };
-
-  const handleToggleComplete = (taskId: string) => {
-    const task = getTaskById(taskId);
-    const nextCompleted = task ? !task.completed : false;
-    setTasks((prev) =>
-      normaliseOrders(
-        prev.map((current) =>
-          current.id === taskId ? { ...current, completed: nextCompleted, updatedAt: new Date().toISOString() } : current,
-        ),
-      ),
-    );
-    setLiveMessage(`${task?.title ?? 'Task'} marked as ${nextCompleted ? 'complete' : 'incomplete'}.`);
-  };
-
-  const handleEditTask = () => {
-    setLiveMessage('Edit action coming soon.');
-  };
-
-  const handleDeleteTask = (taskId: string) => {
-    const task = getTaskById(taskId);
-    setTasks((prev) => prev.filter((task) => task.id !== taskId));
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      next.delete(taskId);
-      return next;
-    });
-    setLiveMessage(`${task?.title ?? 'Task'} deleted.`);
-  };
-
-  const handleRequestSchedule = (taskId: string) => {
-    setScheduleTaskId(taskId);
-    setLiveMessage(`Schedule options opened for ${getTaskById(taskId)?.title ?? 'task'}.`);
-  };
-
-  const handleCloseSchedule = () => {
-    setScheduleTaskId(undefined);
-    setLiveMessage('Schedule popover closed.');
-  };
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (!flatTaskIds.length) return;
-    const currentIndex = focusedId ? flatTaskIds.indexOf(focusedId) : -1;
-
-    switch (event.key) {
-      case 'ArrowDown': {
-        event.preventDefault();
-        const nextIndex = Math.min(flatTaskIds.length - 1, currentIndex + 1);
-        const targetId = flatTaskIds[nextIndex];
-        if (targetId) {
-          setFocusedId(targetId);
-          if (event.shiftKey) {
-            rangeSelect(targetId);
-          } else {
-            setAnchorId(targetId);
-            if (!event.metaKey && !event.ctrlKey && !selectedIds.has(targetId)) {
-              replaceSelection(targetId);
-            }
-          }
-        }
-        break;
-      }
-      case 'ArrowUp': {
-        event.preventDefault();
-        const nextIndex = Math.max(0, currentIndex - 1);
-        const targetId = flatTaskIds[nextIndex];
-        if (targetId) {
-          setFocusedId(targetId);
-          if (event.shiftKey) {
-            rangeSelect(targetId);
-          } else {
-            setAnchorId(targetId);
-            if (!event.metaKey && !event.ctrlKey && !selectedIds.has(targetId)) {
-              replaceSelection(targetId);
-            }
-          }
-        }
-        break;
-      }
-      case 'Home': {
-        event.preventDefault();
-        const targetId = flatTaskIds[0];
-        if (targetId) {
-          setFocusedId(targetId);
-          if (event.shiftKey) {
-            rangeSelect(targetId);
-          } else {
-            replaceSelection(targetId);
-          }
-        }
-        break;
-      }
-      case 'End': {
-        event.preventDefault();
-        const targetId = flatTaskIds[flatTaskIds.length - 1];
-        if (targetId) {
-          setFocusedId(targetId);
-          if (event.shiftKey) {
-            rangeSelect(targetId);
-          } else {
-            replaceSelection(targetId);
-          }
-        }
-        break;
-      }
-      case ' ': {
-        event.preventDefault();
-        if (!focusedId) break;
-        if (keyboardDrag.id === focusedId) {
-          finalizeKeyboardDrop();
-        } else if (keyboardDrag.id) {
-          finalizeKeyboardDrop();
-        } else {
-          toggleSelect(focusedId);
-          beginKeyboardDrag(focusedId);
-        }
-        break;
-      }
-      case 'Escape': {
-        if (keyboardDrag.id) {
-          cancelKeyboardDrag();
-          event.preventDefault();
-          return;
-        }
-        if (selectedIds.size > 0) {
-          clearSelection();
-          event.preventDefault();
-        }
-        break;
-      }
-      case 'Enter': {
-        if (focusedId) {
-          toggleSelect(focusedId);
-          event.preventDefault();
-        }
-        break;
-      }
-      default:
-        if (keyboardDrag.id) {
-          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-            event.preventDefault();
-            moveKeyboardDrag(event.key === 'ArrowDown' ? 1 : -1);
-          }
-        }
-    }
-  };
-
-  const handleDragStart = (taskId: string) => {
-    setDraggingId(taskId);
-    setDropPreview(null);
-    if (!selectedIds.has(taskId)) {
-      replaceSelection(taskId);
-    }
-    setLiveMessage(`Picked up ${getTaskById(taskId)?.title ?? 'task'}.`);
-  };
-
-  const handleDragTarget = (taskId: string, position: DropPosition | null) => {
-    if (!taskId) {
-      setDropPreview(null);
-      return;
-    }
-    setDropPreview({ id: taskId, position });
-  };
-
-  const handleDropTask = (sourceId: string, targetId: string, position: DropPosition | null) => {
-    if (!position) {
-      triggerShake(targetId);
-      setLiveMessage('Cannot drop there.');
-      setDraggingId(undefined);
-      setDropPreview(null);
-      return;
-    }
-    const sourceTask = getTaskById(sourceId);
-    const targetTask = getTaskById(targetId);
-    const result = reorderWithinGroup(tasks, sourceId, targetId, position);
-    if (!result) {
-      triggerShake(targetId);
-      setLiveMessage('Only tasks within the same section can be reordered.');
-    } else {
-      setTasks(result);
-      setLiveMessage(
-        `Moved ${sourceTask?.title ?? 'task'} ${position} ${targetTask?.title ?? 'task'}.`,
-      );
-    }
-    setDraggingId(undefined);
-    setDropPreview(null);
-  };
-
-  const handleDragEnd = () => {
-    setDraggingId(undefined);
-    setDropPreview(null);
-  };
-
-  const beginKeyboardDrag = (taskId: string) => {
-    const index = flatTaskIds.indexOf(taskId);
-    setKeyboardDrag({ id: taskId, originIndex: index });
-    setLiveMessage(`Picked up ${getTaskById(taskId)?.title ?? 'task'}. Use arrow keys to move, space to drop.`);
-  };
-
-  const moveKeyboardDrag = (direction: 1 | -1) => {
-    if (!keyboardDrag.id) return;
-    const currentIndex = flatTaskIds.indexOf(keyboardDrag.id);
-    const targetIndex = currentIndex + direction;
-    const targetId = flatTaskIds[targetIndex];
-    if (!targetId) {
-      triggerShake(keyboardDrag.id);
-      setLiveMessage('No more tasks in that direction.');
-      return;
-    }
-
-    const movingTask = getTaskById(keyboardDrag.id);
-    const targetTask = getTaskById(targetId);
-    const result = reorderWithinGroup(tasks, keyboardDrag.id, targetId, direction > 0 ? 'after' : 'before');
-    if (!result) {
-      triggerShake(keyboardDrag.id);
-      setLiveMessage('Cannot move task outside its section.');
-      return;
-    }
-    setTasks(result);
-    setFocusedId(keyboardDrag.id);
-    setLiveMessage(
-      `Moved ${movingTask?.title ?? 'task'} ${direction > 0 ? 'after' : 'before'} ${
-        targetTask?.title ?? 'task'
-      }.`,
-    );
-  };
-
-  const finalizeKeyboardDrop = () => {
-    if (!keyboardDrag.id) return;
-    const droppedTask = keyboardDrag.id ? getTaskById(keyboardDrag.id) : focusedId ? getTaskById(focusedId) : undefined;
-    setKeyboardDrag({ id: null, originIndex: -1 });
-    setLiveMessage(`Dropped ${droppedTask?.title ?? 'task'}.`);
-  };
-
-  const cancelKeyboardDrag = () => {
-    if (!keyboardDrag.id) return;
-    setKeyboardDrag({ id: null, originIndex: -1 });
-    setLiveMessage('Cancelled move.');
-  };
-
-  const toggleSelect = (taskId: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(taskId)) {
-        next.delete(taskId);
-      } else {
-        next.add(taskId);
-      }
-      setAnchorId(taskId);
-      return next;
-    });
-  };
-
-  const replaceSelection = (taskId: string) => {
-    setSelectedIds(new Set([taskId]));
-    setAnchorId(taskId);
-  };
-
-  const rangeSelect = (taskId: string) => {
-    const startId = anchorId ?? focusedId ?? taskId;
-    const startIndex = flatTaskIds.indexOf(startId);
-    const endIndex = flatTaskIds.indexOf(taskId);
-    if (startIndex === -1 || endIndex === -1) return;
-    const [from, to] = startIndex < endIndex ? [startIndex, endIndex] : [endIndex, startIndex];
-    const ids = flatTaskIds.slice(from, to + 1);
-    setSelectedIds(new Set(ids));
-  };
-
-  const clearSelection = () => {
-    setSelectedIds(new Set());
-  };
-
-  const handleQuickAddSubmit = () => {
-    const trimmed = quickAddValue.trim();
-    if (!trimmed) return;
-    const newTask: Task = {
-      id: `task-${Date.now()}`,
-      title: trimmed,
-      description: '',
-      due: filter === 'upcoming' ? shiftDayISO(1) : shiftDayISO(0),
-      priority: 'medium',
-      tags: [],
-      projectId: undefined,
-      completed: false,
-      updatedAt: new Date().toISOString(),
-      order: tasks.length + 1,
-    };
-    setTasks((prev) => normaliseOrders([newTask, ...prev]));
-    setQuickAddValue('');
-    setFocusedId(newTask.id);
-    replaceSelection(newTask.id);
-    setLiveMessage(`Added ${newTask.title}.`);
-  };
-
-  const handleBulkComplete = () => {
-    if (!selectedIds.size) return;
-    setTasks((prev) =>
-      normaliseOrders(
-        prev.map((task) =>
-          selectedIds.has(task.id) ? { ...task, completed: true, updatedAt: new Date().toISOString() } : task,
-        ),
-      ),
-    );
-    setLiveMessage('Selected tasks completed.');
-  };
-
-  const handleBulkDelete = () => {
-    if (!selectedIds.size) return;
-    setTasks((prev) => prev.filter((task) => !selectedIds.has(task.id)));
-    clearSelection();
-    setLiveMessage('Selected tasks deleted.');
-  };
-
-  const getTaskById = (taskId: string) => tasks.find((task) => task.id === taskId);
+  const [selectedProductId, setSelectedProductId] = useState(products[0].id);
+  const [expanded, setExpanded] = useState(false);
+  const [panelTab, setPanelTab] = useState<PanelTab>('Overview');
+  const [detailTab, setDetailTab] = useState<DetailTab>('Variants');
+  const selected = useMemo(() => products.find((p) => p.id === selectedProductId) ?? products[0], [selectedProductId]);
 
   return (
-    <PageShell>
-      <TodoToolbar
-        filter={filter}
-        onFilterChange={(next) => {
-          setFilter(next);
-          setFocusedId(undefined);
-        }}
-        availableTags={availableTags}
-        activeTag={tagFilter}
-        onTagChange={(tag) => setTagFilter(tag)}
-        sort={sort}
-        onSortChange={setSort}
-        onNewTask={() => {
-          quickAddFocusRef.current?.focus();
-        }}
-      />
-
-      <ContentArea>
-        <TodoList
-          groups={groups}
-          selectedIds={selectedIds}
-          focusedId={focusedId}
-          draggingId={draggingId}
-          keyboardDraggingId={keyboardDrag.id ?? undefined}
-          dropPreview={dropPreview}
-          shakeIds={shakeIds}
-          scheduleOpenId={scheduleTaskId}
-          quickAddValue={quickAddValue}
-          quickAddRef={quickAddFocusRef}
-          onQuickAddChange={setQuickAddValue}
-          onQuickAddSubmit={handleQuickAddSubmit}
-          onQuickAddCancel={() => setQuickAddValue('')}
-          onFocusTask={handleFocusTask}
-          onSelectTask={handleSelectTask}
-          onToggleComplete={handleToggleComplete}
-          onEditTask={handleEditTask}
-          onDeleteTask={handleDeleteTask}
-          onRequestSchedule={handleRequestSchedule}
-          onCloseSchedule={handleCloseSchedule}
-          onListKeyDown={handleKeyDown}
-          onDragStart={handleDragStart}
-          onDragTarget={handleDragTarget}
-          onDropTask={handleDropTask}
-          onDragEnd={handleDragEnd}
-        />
-        {selectedIds.size > 1 ? (
-          <TodoBulkBar
-            selectedCount={selectedIds.size}
-            onCompleteSelected={handleBulkComplete}
-            onDeleteSelected={handleBulkDelete}
-            onClearSelection={clearSelection}
-          />
-        ) : null}
-      </ContentArea>
-
-      <LiveRegion role="status" aria-live="polite">
-        {liveMessage}
-      </LiveRegion>
-    </PageShell>
+    <Page>
+      {!expanded && (
+        <SplitLayout>
+          <Catalogue>
+            <h1>Products</h1>
+            <p>View and manage all products across all areas and brands.</p>
+            <Table>
+              <thead><tr><th>Product name</th><th>Code</th><th>Brand</th><th>Category</th><th>RRP</th><th>Status</th><th>Stock</th></tr></thead>
+              <tbody>
+                {products.map((p) => (
+                  <tr key={p.id} onClick={() => setSelectedProductId(p.id)} data-active={p.id === selectedProductId}>
+                    <td>{p.name}</td><td>{p.code}</td><td>{p.brand}</td><td>{p.category}</td><td>{p.rrp}</td><td><Badge>{p.status}</Badge></td><td>{p.stock}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Catalogue>
+          <SidePanel>
+            <button onClick={() => setExpanded(true)}>Expand full details ↗</button>
+            <h2>{selected.name}</h2>
+            <Small>Product code {selected.code}</Small>
+            <TabRow>{(['Overview', 'Variants', 'Inventory', 'Suppliers', 'Media', 'History'] as PanelTab[]).map((t) => <Tab key={t} data-active={panelTab===t} onClick={() => setPanelTab(t)}>{t}</Tab>)}</TabRow>
+            <Card>{panelTab} content (prototype dummy data)</Card>
+          </SidePanel>
+        </SplitLayout>
+      )}
+      {expanded && (
+        <FullView>
+          <Top><button onClick={() => setExpanded(false)}>← Back to catalogue split view</button><h1>{selected.name}</h1></Top>
+          <Grid>
+            <Card><h3>Media</h3><p>7 assets</p><MediaGrid>{Array.from({ length: 6 }).map((_, i) => <Asset key={i}>{i === 5 ? '+2' : 'IMG'}</Asset>)}</MediaGrid></Card>
+            <Card><h3>Product summary</h3><p>Brand: {selected.brand}</p><p>Category: Tailoring › Blazers</p><p>Season: AW24</p><p>Country: China</p></Card>
+            <Card><h3>Commercials</h3><p>RRP: £45.00</p><p>Cost price: £18.00</p><p>Margin: 60.0%</p></Card>
+          </Grid>
+          <Card>
+            <TabRow>{(['Variants', 'Attributes', 'Inventory', 'Suppliers', 'Media', 'History', 'Change log'] as DetailTab[]).map((t) => <Tab key={t} data-active={detailTab===t} onClick={() => setDetailTab(t)}>{t}</Tab>)}</TabRow>
+            {detailTab === 'Variants' ? (
+              <Table><thead><tr><th>Size</th><th>Colour</th><th>SKU</th><th>EAN</th><th>Status</th><th>Stock</th><th>Available</th><th>RRP</th></tr></thead><tbody>{variants.map((v)=><tr key={v.sku}><td>{v.size}</td><td>Black</td><td>{v.sku}</td><td>{v.ean}</td><td><Badge>LIVE</Badge></td><td>{v.stock}</td><td>{v.available}</td><td>£45.00</td></tr>)}</tbody></Table>
+            ) : <Card>{detailTab} tab content (dummy data)</Card>}
+          </Card>
+        </FullView>
+      )}
+    </Page>
   );
 }
 
-function buildGroups(
-  tasks: Task[],
-  filter: TaskFilter,
-  sort: TaskSort,
-  tagFilter: string | null,
-  now: Date,
-): TaskGroup[] {
-  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-
-  const filtered = tasks.filter((task) => {
-    if (tagFilter && !task.tags.some((tag) => tag === tagFilter)) return false;
-    if (filter === 'today') {
-      if (task.completed) return true;
-      if (!task.due) return false;
-      const due = new Date(task.due);
-      return due < end;
-    }
-    if (filter === 'upcoming') {
-      if (task.completed) return true;
-      if (!task.due) return true;
-      const due = new Date(task.due);
-      return due >= end;
-    }
-    return true;
-  });
-
-  const comparator = createComparator(sort, start);
-
-  const buckets: Record<GroupKey, Task[]> = {
-    overdue: [],
-    today: [],
-    upcoming: [],
-    completed: [],
-  };
-
-  for (const task of filtered) {
-    const key = getGroupKey(task, start, end);
-    buckets[key].push(task);
-  }
-
-  (Object.keys(buckets) as GroupKey[]).forEach((key) => {
-    buckets[key].sort(comparator);
-  });
-
-  const groups: TaskGroup[] = [];
-  if (buckets.overdue.length) {
-    groups.push({ id: 'overdue', label: 'Overdue', tasks: buckets.overdue });
-  }
-  if (buckets.today.length) {
-    groups.push({ id: 'today', label: 'Today', tasks: buckets.today });
-  }
-  if (buckets.upcoming.length) {
-    groups.push({ id: 'upcoming', label: 'Upcoming', tasks: buckets.upcoming });
-  }
-  if (buckets.completed.length) {
-    groups.push({ id: 'completed', label: 'Completed', tasks: buckets.completed });
-  }
-
-  return groups;
-}
-
-function getGroupKey(task: Task, start: Date, end: Date): GroupKey {
-  if (task.completed) return 'completed';
-  if (!task.due) return 'upcoming';
-  const due = new Date(task.due);
-  if (due < start) return 'overdue';
-  if (due >= start && due < end) return 'today';
-  return 'upcoming';
-}
-
-function createComparator(sort: TaskSort, todayStart: Date) {
-  const priorityRank: Record<Task['priority'], number> = {
-    high: 0,
-    medium: 1,
-    low: 2,
-  };
-
-  return (a: Task, b: Task) => {
-    if (sort === 'due') {
-      const aDue = a.due ? new Date(a.due).getTime() : Number.POSITIVE_INFINITY;
-      const bDue = b.due ? new Date(b.due).getTime() : Number.POSITIVE_INFINITY;
-      if (aDue !== bDue) return aDue - bDue;
-    } else if (sort === 'priority') {
-      const diff = priorityRank[a.priority] - priorityRank[b.priority];
-      if (diff !== 0) return diff;
-    } else if (sort === 'updated') {
-      const diff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-      if (diff !== 0) return diff;
-    }
-    return a.order - b.order;
-  };
-}
-
-function reorderWithinGroup(
-  tasks: Task[],
-  sourceId: string,
-  targetId: string,
-  position: DropPosition,
-): Task[] | null {
-  if (sourceId === targetId) return normaliseOrders(tasks);
-  const start = new Date();
-  const todayStart = new Date(start.getFullYear(), start.getMonth(), start.getDate());
-  const todayEnd = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 1);
-
-  const sourceTask = tasks.find((task) => task.id === sourceId);
-  const targetTask = tasks.find((task) => task.id === targetId);
-  if (!sourceTask || !targetTask) return null;
-
-  const sourceKey = getGroupKey(sourceTask, todayStart, todayEnd);
-  const targetKey = getGroupKey(targetTask, todayStart, todayEnd);
-
-  if (sourceKey !== targetKey) {
-    return null;
-  }
-
-  const updated = [...tasks];
-  const sourceIndex = updated.findIndex((task) => task.id === sourceId);
-  const [item] = updated.splice(sourceIndex, 1);
-  let targetIndex = updated.findIndex((task) => task.id === targetId);
-  if (targetIndex < 0) return null;
-  if (position === 'after') {
-    targetIndex += 1;
-  }
-  updated.splice(targetIndex, 0, item);
-  return normaliseOrders(updated);
-}
-
-function normaliseOrders(tasks: Task[]): Task[] {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-  const counters = new Map<GroupKey, number>();
-
-  return tasks.map((task) => {
-    const key = getGroupKey(task, start, end);
-    const nextOrder = (counters.get(key) ?? 0) + 1;
-    counters.set(key, nextOrder);
-    return { ...task, order: nextOrder };
-  });
-}
-
-function shiftDayISO(delta: number) {
-  const now = new Date();
-  now.setDate(now.getDate() + delta);
-  now.setHours(9, 0, 0, 0);
-  return now.toISOString();
-}
-
-function shiftTimestamp(dayOffset: number, hourOffset: number) {
-  const now = new Date();
-  now.setDate(now.getDate() + dayOffset);
-  now.setHours(now.getHours() + hourOffset);
-  return now.toISOString();
-}
+const Page = styled.div`padding: 24px; overflow:auto; height:100%;`;
+const SplitLayout = styled.div`display:grid; grid-template-columns: 1fr 380px; gap:16px;`;
+const Catalogue = styled.section`background:#fff; border:1px solid #e7e7e7; border-radius:14px; padding:16px;`;
+const SidePanel = styled.aside`background:#fff; border:1px solid #e7e7e7; border-radius:14px; padding:16px; display:grid; gap:12px; align-content:start;`;
+const FullView = styled.div`display:grid; gap:16px;`;
+const Top = styled.div`display:grid; gap:8px;`;
+const Grid = styled.div`display:grid; grid-template-columns: 2fr 1fr 1fr; gap:12px;`;
+const Card = styled.section`background:#fff; border:1px solid #e7e7e7; border-radius:14px; padding:14px;`;
+const Table = styled.table`
+  width:100%; border-collapse: collapse; font-size:14px;
+  th,td{border-bottom:1px solid #efefef; padding:10px; text-align:left;}
+  tbody tr[data-active='true']{background:#f4f7ff;}
+  tbody tr{cursor:pointer;}
+`;
+const Badge = styled.span`background:#dff3e2; color:#2d7e3c; border-radius:999px; padding:2px 8px; font-size:12px; font-weight:700;`;
+const TabRow = styled.div`display:flex; gap:8px; flex-wrap:wrap;`;
+const Tab = styled.button`
+  border:1px solid #ddd; background:#fff; padding:6px 10px; border-radius:999px; cursor:pointer;
+  &[data-active='true']{background:#111; color:#fff; border-color:#111;}
+`;
+const Small = styled.p`margin:0; color:#666;`;
+const MediaGrid = styled.div`display:grid; grid-template-columns: repeat(3, 1fr); gap:8px;`;
+const Asset = styled.div`height:90px; border-radius:8px; background:#ececec; display:grid; place-items:center; font-weight:700;`;


### PR DESCRIPTION
### Motivation
- Deliver an interactive prototype that matches the brief: an initial catalogue view with a right-side details preview and an expandable full-details view. 
- Provide working tabs and interactions wired to dummy data so the UI can be used as a high-fidelity prototype rather than static images.

### Description
- Replaced the previous To-Do route implementation with a product-management prototype in `src/routes/TodoPage.tsx` that renders a split catalogue + preview panel and an expanded full-detail view. 
- Added in-memory dummy datasets for `products` and `variants` and wired selection state so clicking rows updates the side panel and expanded view. 
- Implemented working tab controls for the side preview (`Overview`, `Variants`, `Inventory`, `Suppliers`, `Media`, `History`) and for the full detail view (including `Variants`, `Attributes`, `Inventory`, `Suppliers`, `Media`, `History`, `Change log`) with a concrete variants table and placeholder content for other tabs. 
- Added scoped styled-components for layout (catalogue table, side panel, cards, tabs, media grid, badges) to present a clickable prototype UI.

### Testing
- Ran `npm run lint` (TypeScript check via `tsc --noEmit`) and it failed with pre-existing TypeScript errors in unrelated Notes/PARA modules, so lint did not pass. 
- No other automated tests were added or executed for this prototype change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd113a58c832d838d218738620877)